### PR TITLE
saving model, refactor evaluation

### DIFF
--- a/cnn_model.py
+++ b/cnn_model.py
@@ -1,45 +1,22 @@
-from preprocessing import preprocess_images
-import os
-import random
 from efficientnet.keras import EfficientNetB0
 from keras.models import Sequential
 from keras.layers import Conv2D, MaxPooling2D, Flatten, Dense
-import numpy as np
-import matplotlib.pyplot as plt
-from keras.datasets import mnist
-from keras.utils import to_categorical
-from imgaug import augmenters as iaa
-from PIL import Image
-from sklearn.metrics import confusion_matrix
-from utils import collect_image_paths, plot_confusion_matrix, populate_formatted_image_array, generate_training_labels
-from utils import IMAGE_HEIGHT, IMAGE_WIDTH
-
-root_dir = 'dataset'
-excluded_folder = "original_only"
+from utils import NUM_CLASSES, collect_image_paths, populate_formatted_image_array, generate_training_labels
+from utils import IMAGE_HEIGHT, IMAGE_WIDTH, ROOT_DIR, EXCLUDED_FOLDER
 
 # collecting data on training/testing images used, populating arrays for paths of selected training/testing images
-num_images_used_train, \
-num_images_used_test, \
-selected_image_paths_train, \
-selected_image_paths_test = collect_image_paths(
-    root_dir, excluded_folder
-)
-
-print(f"Total training images used: {num_images_used_train}")
-print(f"Total testing images used: {num_images_used_test}")
+num_images_used_train, _, selected_image_paths_train, _ = collect_image_paths(ROOT_DIR, EXCLUDED_FOLDER)
 
 train_images = populate_formatted_image_array(selected_image_paths_train)
-test_images = populate_formatted_image_array(selected_image_paths_test)
 
 image_height = IMAGE_HEIGHT
 image_width = IMAGE_WIDTH
+num_classes = NUM_CLASSES
 num_channels = 3
-num_classes = 7
 num_epochs = 10
 batch_size = 32
 
 train_labels = generate_training_labels(selected_image_paths_train)
-test_labels = generate_training_labels(selected_image_paths_test)
 
 base_model = EfficientNetB0(weights='imagenet', include_top=False, input_shape=(image_height, image_width, num_channels))
 model = Sequential()
@@ -50,14 +27,5 @@ model.add(Dense(units=num_classes, activation='softmax'))
 model.compile(optimizer='adam', loss='sparse_categorical_crossentropy', metrics=['accuracy'])
 model.fit(train_images, train_labels, epochs=num_epochs, batch_size=batch_size)
 
-# Evaluation
-test_loss, test_accuracy = model.evaluate(test_images, test_labels)
-print('Test Loss:', test_loss)
-print('Test Accuracy:', test_accuracy)
-
-# Predictions
-predictions = model.predict(test_images)
-predicted_labels = np.argmax(predictions, axis=1)
-
-# Plot confusion matrix
-plot_confusion_matrix(test_labels, predicted_labels, num_classes)
+# Save model - don't retrain
+model.save('cnn_model.h5')

--- a/model_evaluation.py
+++ b/model_evaluation.py
@@ -1,0 +1,24 @@
+import numpy as np
+import keras
+
+from keras.models import load_model
+from efficientnet.tfkeras import EfficientNetB0
+from utils import EXCLUDED_FOLDER, NUM_CLASSES, ROOT_DIR, collect_image_paths, generate_training_labels, plot_confusion_matrix, populate_formatted_image_array
+
+_, num_images_used_test, _, selected_image_paths_test = collect_image_paths(ROOT_DIR, EXCLUDED_FOLDER)
+test_images = populate_formatted_image_array(selected_image_paths_test)
+test_labels = generate_training_labels(selected_image_paths_test)
+
+model = load_model('cnn_model.h5')
+
+# Evaluation
+test_loss, test_accuracy = model.evaluate(test_images, test_labels)
+print('Test Loss:', test_loss)
+print('Test Accuracy:', test_accuracy)
+
+# Predictions
+predictions = model.predict(test_images)
+predicted_labels = np.argmax(predictions, axis=1)
+
+# Plot confusion matrix
+plot_confusion_matrix(test_labels, predicted_labels, NUM_CLASSES)

--- a/utils.py
+++ b/utils.py
@@ -4,9 +4,12 @@ import numpy as np
 from PIL import Image
 from sklearn.metrics import confusion_matrix
 
-# constants: current dimensions
+# constants
 IMAGE_WIDTH = 32
 IMAGE_HEIGHT = 32
+NUM_CLASSES = 7
+ROOT_DIR = 'dataset'
+EXCLUDED_FOLDER = "original_only"
 
 # reusable functions
 selected_image_paths_train = []


### PR DESCRIPTION
I'm thinking that when you add the next dataset you can make a cnn_model_v2.py file or something and then train it on the new images from there so it loads faster and we can separate the training stages

Also, looks like the h5 extension is deprecated, and we can change the model to be .keras instead of .h5 (pretty small change, just need to delete the initial model, change the file type, re-initialize, and then change the .h5 to .keras in model_evaluation.py)

I could do that but I just tested on .h5 (successfully) and it'll take a little bit for everything to load with the changes and I'm not sure how soon you need those